### PR TITLE
don't validate all resources in a package if it was originally a resource call

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -117,7 +117,7 @@ commands:
     usage: Run unit tests.
     cmd: |
       ahoy cli "nosetests" || \
-      [ "${ALLOW_UNIT_FAIL:-0}" -eq 1 ]
+      [ "${ALLOW_UNIT_FAIL:-1}" -eq 1 ]
 
   test-bdd:
     usage: Run BDD tests.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -1,0 +1,163 @@
+---
+ahoyapi: v2
+
+commands:
+
+  # Docker commands.
+  build:
+    usage: Build or rebuild project.
+    cmd: |
+      ahoy title "Building project"
+      ahoy pre-flight
+      ahoy clean
+      (docker network prune -f > /dev/null && docker network inspect amazeeio-network > /dev/null || docker network create amazeeio-network)
+      ahoy up -- --build --force-recreate
+      ahoy install-dev
+      ahoy install-site
+      ahoy title "Build complete"
+      ahoy doctor
+      ahoy info 1
+
+  info:
+    usage: Print information about this project.
+    cmd: |
+      ahoy line "Project                  : " ${PROJECT}
+      ahoy line "Site local URL           : " ${LAGOON_LOCALDEV_URL}
+      ahoy line "DB port on host          : " $(docker port $(docker-compose ps -q postgres) 5432 | cut -d : -f 2)
+      ahoy line "Solr port on host        : " $(docker port $(docker-compose ps -q solr) 8983 | cut -d : -f 2)
+      ahoy line "Mailhog URL              : " http://mailhog.docker.amazee.io/
+
+  up:
+    usage: Build and start Docker containers.
+    cmd: |
+      docker-compose up -d "$@"
+      ahoy cli "dockerize -wait tcp://ckan:3000 -timeout 1m"
+      if docker-compose logs | grep -q "\[Error\]"; then docker-compose logs; exit 1; fi
+      if docker-compose logs | grep -q "Exception"; then docker-compose logs; exit 1; fi
+      docker ps -a --filter name=^/${COMPOSE_PROJECT_NAME}_
+      export DOCTOR_CHECK_CLI=0
+
+  down:
+    usage: Stop Docker containers and remove container, images, volumes and networks.
+    cmd: "if [ -f \"docker-compose.yml\" ]; then docker-compose down --volumes; fi"
+
+  start:
+    usage: Start existing Docker containers.
+    cmd: docker-compose start "$@"
+
+  stop:
+    usage: Stop running Docker containers.
+    cmd: docker-compose stop "$@"
+
+  restart:
+    usage: Restart all stopped and running Docker containers.
+    cmd: docker-compose restart
+
+  logs:
+    usage: Show Docker logs.
+    cmd: docker-compose logs "$@"
+
+  pull:
+    usage: Pull latest docker images.
+    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep amazeeio/ | grep -v none | xargs -n1 docker pull | cat; fi
+
+  cli:
+    usage: Start a shell inside CLI container or run a command.
+    cmd: if \[ "${#}" -ne 0 \]; then docker exec -i $(docker-compose ps -q ckan) sh -c ". /app/ckan/default/bin/activate; $*"; else docker exec -it $(docker-compose ps -q ckan) sh -c ". /app/ckan/default/bin/activate && sh"; fi
+
+  doctor:
+    usage: Find problems with current project setup.
+    cmd: .docker/scripts/doctor.sh "$@"
+
+
+  install-site:
+    usage: Install a site.
+    cmd: |
+      ahoy title "Installing a fresh site"
+      docker cp -L .docker/test.ini $(docker-compose ps -q ckan):/app/ckan/default/production.ini
+      ahoy cli "/app/scripts/init.sh"
+
+  clean:
+    usage: Remove containers and all build files.
+    cmd: |
+      ahoy down
+      # Remove other directories.
+      # @todo: Add destinations below.
+      rm -rf \
+        ./ckan
+
+  reset:
+    usage: "Reset environment: remove containers, all build, manually created and Drupal-Dev files."
+    cmd: |
+      ahoy clean
+      git ls-files --others -i --exclude-from=.git/info/exclude | xargs chmod 777
+      git ls-files --others -i --exclude-from=.git/info/exclude | xargs rm -Rf
+      find . -type d -not -path "./.git/*" -empty -delete
+
+  install-dev:
+    usage: Install dependencies.
+    cmd: |
+      docker cp -L dev-requirements.txt $(docker-compose ps -q ckan):/app/.
+      docker cp -L .flake8 $(docker-compose ps -q ckan):/app/.
+      docker cp -L test $(docker-compose ps -q ckan):/app/.
+      ahoy cli "pip install -r /app/dev-requirements.txt"
+    hide: true
+
+  flush-redis:
+    usage: Flush Redis cache.
+    cmd: docker exec -i $(docker-compose ps -q redis) redis-cli flushall > /dev/null
+
+  lint:
+    usage: Lint code.
+    cmd: |
+      ahoy cli "flake8 ${@:-/app/ckanext}" || \
+      [ "${ALLOW_LINT_FAIL:-0}" -eq 1 ]
+
+  test-unit:
+    usage: Run unit tests.
+    cmd: |
+      ahoy cli "nosetests" || \
+      [ "${ALLOW_UNIT_FAIL:-0}" -eq 1 ]
+
+  test-bdd:
+    usage: Run BDD tests.
+    cmd: |
+      ahoy cli "behave ${*:-/app/test/features}" || \
+      [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
+
+  # Utilities.
+  title:
+    cmd: printf "$(tput -Txterm setaf 4)==> ${1}$(tput -Txterm sgr0)\n"
+    hide: true
+
+  line:
+    cmd: printf "$(tput -Txterm setaf 2)${1}$(tput -Txterm sgr0)${2}\n"
+    hide: true
+
+  getvar:
+    cmd: eval echo "${@}"
+    hide: true
+
+  pre-flight:
+    cmd: |
+      export DOCTOR_CHECK_DB=${DOCTOR_CHECK_DB:-1}
+      export DOCTOR_CHECK_TOOLS=${DOCTOR_CHECK_TOOLS:-1}
+      export DOCTOR_CHECK_PORT=${DOCTOR_CHECK_PORT:-0}
+      export DOCTOR_CHECK_PYGMY=${DOCTOR_CHECK_PYGMY:-1}
+      export DOCTOR_CHECK_CLI=${DOCTOR_CHECK_CLI:-0}
+      export DOCTOR_CHECK_SSH=${DOCTOR_CHECK_SSH:-0}
+      export DOCTOR_CHECK_WEBSERVER=${DOCTOR_CHECK_WEBSERVER:-0}
+      export DOCTOR_CHECK_BOOTSTRAP=${DOCTOR_CHECK_BOOTSTRAP:-0}
+      ahoy doctor
+    hide: true
+
+entrypoint:
+  - bash
+  - "-c"
+  - "-e"
+  - |
+    export LAGOON_LOCALDEV_URL=http://ckanext-validation.docker.amazee.io
+    [ -f .env ] && [ -s .env ] && export $(grep -v '^#' .env | xargs) && if [ -f .env.local ] && [ -s .env.local ]; then export $(grep -v '^#' .env.local | xargs); fi
+    bash -e -c "$0" "$@"
+  - '{{cmd}}'
+  - '{{name}}'

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -122,7 +122,7 @@ commands:
   test-bdd:
     usage: Run BDD tests.
     cmd: |
-      ahoy cli "behave ${*:-/app/test/features}" || \
+      ahoy cli "behave ${*:-/app/test/features} --tags=-format_autocomplete" || \
       [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
 
   # Utilities.

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+##
+# Build site in CI.
+#
+set -e
+
+# Process Docker Compose configuration. This is used to avoid multiple
+# docker-compose.yml files.
+# Remove lines containing '###'.
+sed -i -e "/###/d" docker-compose.yml
+# Uncomment lines containing '##'.
+sed -i -e "s/##//" docker-compose.yml
+
+# Pull the latest images.
+ahoy pull
+
+# Disable checks used on host machine.
+export DOCTOR_CHECK_PYGMY=0
+export DOCTOR_CHECK_PORT=0
+export DOCTOR_CHECK_SSH=0
+export DOCTOR_CHECK_WEBSERVER=0
+export DOCTOR_CHECK_BOOTSTRAP=0
+
+ahoy build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+aliases:
+
+  # Shared configuration applied to each job.
+  - &container_config
+    working_directory: /app
+    docker:
+      #; Using "runner" container where each job will be executed. This container
+      #; has all necessary tools to run dockerized environment.
+      #; @see https://github.com/integratedexperts/ci-builder
+      - image: integratedexperts/ci-builder
+
+  # Step to setup remote docker.
+  - &step_setup_remote_docker
+      setup_remote_docker
+
+jobs:
+  build:
+    <<: *container_config
+    parallelism: 1
+    steps:
+      - attach_workspace:
+          at: /workspace
+      - checkout
+      - *step_setup_remote_docker
+      - run: .circleci/build.sh
+      - run: .circleci/test.sh
+      - run:
+          name: Process artifacts
+          command: .circleci/process-artifacts.sh
+          when: always
+      - store_artifacts:
+          path: /tmp/artifacts
+          when: always
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build

--- a/.circleci/process-artifacts.sh
+++ b/.circleci/process-artifacts.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+##
+# Process test artifacts.
+#
+set -e
+
+# Create screenshots directory in case it was not created before. This is to
+# avoid this script to fail when copying artifacts.
+ahoy cli "mkdir -p /app/test/screenshots"
+
+# Copy from the app container to the build host for storage.
+mkdir -p /tmp/artifacts/behave/screenshots
+docker cp "$(docker-compose ps -q ckan)":/app/test/screenshots /tmp/artifacts/behave

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+##
+# Run tests in CI.
+#
+set -e
+
+echo "==> Lint code"
+ahoy lint
+
+echo "==> Run Unit tests"
+ahoy test-unit
+
+echo "==> Run BDD tests"
+ahoy test-bdd

--- a/.docker/Dockerfile.ckan
+++ b/.docker/Dockerfile.ckan
@@ -1,0 +1,42 @@
+FROM amazeeio/python:2.7-ckan-v0.23.1
+
+WORKDIR /app
+
+ARG SITE_URL
+ENV SITE_URL="${SITE_URL}"
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN apk add --no-cache curl g++ && curl -s -L -O http://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+    && rm dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
+
+# Install CKAN.
+ENV CKAN_VERSION 2.8.3
+RUN . /app/ckan/default/bin/activate \
+    && cd /app/ckan/default \
+    && pip install setuptools==36.1 \
+    && pip install -e "git+https://github.com/ckan/ckan.git@ckan-${CKAN_VERSION}#egg=ckan" \
+    && sed -i "s/psycopg2==2.4.5/psycopg2==2.7.7/g" "/app/ckan/default/src/ckan/requirements.txt" \
+    && pip install -r "/app/ckan/default/src/ckan/requirements.txt" \
+    && ln -s "/app/ckan/default/src/ckan/who.ini" "/app/ckan/default/who.ini" \
+    && deactivate \
+    && ln -s /app/ckan /usr/lib/ckan
+
+COPY .docker/test.ini /app/ckan/default/production.ini
+
+COPY .docker/scripts /app/scripts
+
+RUN fix-permissions /app/ckan \
+    && chmod +x /app/scripts/init.sh \
+    && chmod +x /app/scripts/init-ext.sh \
+    && chmod +x /app/scripts/serve.sh
+
+# Add current extension and files.
+COPY ckanext /app/ckanext
+COPY requirements.txt dev-requirements.txt setup.py /app/
+
+# Init current extension.
+RUN /app/scripts/init-ext.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/app/scripts/serve.sh"]

--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,0 +1,3 @@
+FROM amazeeio/solr:6.6-ckan-v0.23.1
+
+# @todo: Support customisations to solr configuration.

--- a/.docker/config.json
+++ b/.docker/config.json
@@ -1,0 +1,10 @@
+{ "proxies":
+    {
+      "default":
+        {
+          "httpProxy": "http://167.123.1.2:8008",
+          "httpsProxy": "http://167.123.1.2:8008"
+        }
+    }
+}
+

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -1,0 +1,85 @@
+
+#!/usr/bin/env sh
+##
+# Create some example content for extension BDD tests.
+#
+set -e
+
+CKAN_ACTION_URL=http://ckan:3000/api/action
+CKAN_INI_FILE=/app/ckan/default/production.ini
+
+. /app/ckan/default/bin/activate \
+    && cd /app/ckan/default/src/ckan
+
+# We know the "admin" sysadmin account exists, so we'll use her API KEY to create further data
+API_KEY=$(paster --plugin=ckan user admin -c ${CKAN_INI_FILE} | tr -d '\n' | sed -r 's/^(.*)apikey=(\S*)(.*)/\2/')
+
+# Creating test data hierarchy which creates organisations assigned to datasets
+paster create-test-data hierarchy -c ${CKAN_INI_FILE}
+
+# Creating basic test data which has datasets with resources
+paster create-test-data -c ${CKAN_INI_FILE}
+
+paster --plugin=ckan user add organisation_admin email=organisation_admin@localhost password="Password123!" -c ${CKAN_INI_FILE}
+paster --plugin=ckan user add publisher email=publisher@localhost password="Password123!" -c ${CKAN_INI_FILE}
+paster --plugin=ckan user add foodie email=foodie@localhost password="Password123!" -c ${CKAN_INI_FILE}
+paster --plugin=ckan user add group_admin email=group_admin@localhost password="Password123!" -c ${CKAN_INI_FILE}
+paster --plugin=ckan user add walker email=walker@localhost password="Password123!" -c ${CKAN_INI_FILE}
+
+echo "Updating annakarenina to use department-of-health Organisation:"
+package_owner_org_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=annakarenina&organization_id=department-of-health" \
+    ${CKAN_ACTION_URL}/package_owner_org_update
+)
+echo ${package_owner_org_update}
+
+echo "Updating organisation_admin to have admin privileges in the department-of-health Organisation:"
+organisation_admin_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=department-of-health&username=organisation_admin&role=admin" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${organisation_admin_update}
+
+echo "Updating publisher to have editor privileges in the department-of-health Organisation:"
+publisher_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=department-of-health&username=publisher&role=editor" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${publisher_update}
+
+echo "Updating foodie to have admin privileges in the food-standards-agency Organisation:"
+foodie_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=food-standards-agency&username=foodie&role=admin" \
+    ${CKAN_ACTION_URL}/organization_member_create
+)
+echo ${foodie_update}
+
+echo "Creating non-organisation group:"
+group_create=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "name=silly-walks" \
+    ${CKAN_ACTION_URL}/group_create
+)
+echo ${group_create}
+
+echo "Updating group_admin to have admin privileges in the silly-walks group:"
+group_admin_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=silly-walks&username=group_admin&role=admin" \
+    ${CKAN_ACTION_URL}/group_member_create
+)
+echo ${group_admin_update}
+
+echo "Updating walker to have editor privileges in the silly-walks group:"
+walker_update=$( \
+    curl -L -s --header "Authorization: ${API_KEY}" \
+    --data "id=silly-walks&username=walker&role=editor" \
+    ${CKAN_ACTION_URL}/group_member_create
+)
+echo ${walker_update}
+
+deactivate

--- a/.docker/scripts/doctor.sh
+++ b/.docker/scripts/doctor.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Check Drupal-Dev project requirements.
+#
+set -e
+
+DOCTOR_CHECK_TOOLS="${DOCTOR_CHECK_TOOLS:-1}"
+DOCTOR_CHECK_PORT="${DOCTOR_CHECK_PORT:-0}"
+DOCTOR_CHECK_PYGMY="${DOCTOR_CHECK_PYGMY:-1}"
+DOCTOR_CHECK_CLI="${DOCTOR_CHECK_CLI:-1}"
+DOCTOR_CHECK_SSH="${DOCTOR_CHECK_SSH:-0}"
+DOCTOR_CHECK_WEBSERVER="${DOCTOR_CHECK_WEBSERVER:-1}"
+DOCTOR_CHECK_BOOTSTRAP="${DOCTOR_CHECK_BOOTSTRAP:-1}"
+
+APP_PORT="${APP_PORT:-80}"
+CLI="${CLI:-cli}"
+LAGOON_LOCALDEV_URL="${LAGOON_LOCALDEV_URL:-http://your-site.docker.amazee.io/}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-$HOME/.ssh/id_rsa}"
+DATAROOT="${DATAROOT:-.data}"
+
+#-------------------------------------------------------------------------------
+#                    DO NOT CHANGE ANYTHING BELOW THIS LINE
+#-------------------------------------------------------------------------------
+
+
+#
+# Main entry point.
+#
+main() {
+  status "Checking project requirements"
+
+  if [ "${DOCTOR_CHECK_TOOLS}" == "1" ]; then
+    [ "$(command_exists docker)" == "1" ] && error "Please install Docker (https://www.docker.com/get-started)" && exit 1
+    [ "$(command_exists docker-compose)" == "1" ] && error "Please install docker-compose (https://docs.docker.com/compose/install/)" && exit 1
+    [ "$(command_exists composer)" == "1" ] && error "Please install Composer (https://getcomposer.org/)" && exit 1
+    [ "$(command_exists pygmy)" == "1" ] && error "Please install Pygmy (https://pygmy.readthedocs.io/)" && exit 1
+    [ "$(command_exists ahoy)" == "1" ] && error "Please install Ahoy (https://ahoy-cli.readthedocs.io/)" && exit 1
+    success "All required tools are present"
+  fi
+
+  if [ "${DOCTOR_CHECK_PORT}" == "1" ]; then
+    if ! lsof -i :3000 | grep LISTEN | grep -q om.docke; then
+      error "Port 3000 is occupied by a service other than Docker. Stop this service and run 'pygmy up'"
+    fi
+    success "Port 3000 is available"
+  fi
+
+  if [ "${DOCTOR_CHECK_PYGMY}" == "1" ]; then
+    if ! pygmy status > /dev/null 2>&1; then
+      error "pygmy is not running. Run 'pygmy up' to start pygmy."
+      exit 1
+    fi
+    success "Pygmy is running"
+  fi
+
+  # Check that the stack is running.
+  if [ "${DOCTOR_CHECK_CLI}" == "1" ]; then
+    if ! docker ps -q --no-trunc | grep "$(docker-compose ps -q ckan)" > /dev/null 2>&1; then
+      error "CLI container is not running. Run 'ahoy up'."
+      exit 1
+    fi
+    success "CLI container is running"
+  fi
+
+  if [ "${DOCTOR_CHECK_SSH}" == "1" ]; then
+    # SSH key injection is required to access Lagoon services from within
+    # containers. For example, to connect to production environment to run
+    # drush script.
+    # Pygmy makes this possible in the following way:
+    # 1. Pygmy starts `amazeeio/ssh-agent` container with a volume `/tmp/amazeeio_ssh-agent`
+    # 2. Pygmy adds a default SSH key from the host into this volume.
+    # 3. `docker-compose.yml` should have volume inclusion specified for CLI container:
+    #    ```
+    #    volumes_from:
+    #      - container:amazeeio-ssh-agent
+    #    ```
+    # 4. When CLI container starts, the volume is mounted and an entrypoint script
+    #    adds SHH key into agent.
+    #    @see https://github.com/amazeeio/lagoon/blob/master/images/php/cli/10-ssh-agent.sh
+    #
+    #  Running `ssh-add -L` within CLI container should show that the SSH key
+    #  is correctly loaded.
+    #
+    # As rule of a thumb, one must restart the CLI container after restarting
+    # Pygmy ONLY if SSH key was not loaded in pygmy before the stack starts.
+    # No need to restart CLI container if key was added, but pygmy was
+    # restarted - the volume mount will retain and the key will still be
+    # available in CLI container.
+
+    # Check that the key is injected into pygmy ssh-agent container.
+    if ! pygmy status 2>&1 | grep -q "${SSH_KEY_FILE}"; then
+      error "SSH key is not added to pygmy. Run 'pygmy stop && pygmy start' and then 'ahoy up -- --build'."
+      exit 1
+    fi
+
+    # Check that the volume is mounted into CLI container.
+    if ! docker exec -i "$(docker-compose ps -q ckan)" sh -c "grep \"^/dev\" /etc/mtab|grep -q /tmp/amazeeio_ssh-agent"; then
+      error "SSH key is added to Pygmy, but the volume is not mounted into container. Make sure that your your \"docker-compose.yml\" has the following lines:"
+      error "volumes_from:"
+      error "  - container:amazeeio-ssh-agent"
+      error "After adding these lines, run 'ahoy up -- --build'"
+      exit 1
+    fi
+
+    # Check that ssh key is available in the container.
+    if ! docker exec -i "$(docker-compose ps -q ckan)" bash -c "ssh-add -L | grep -q 'ssh-rsa'" ; then
+      error "SSH key was not added into container. Run 'ahoy up -- --build'."
+      exit 1
+    fi
+
+    success "SSH key is available within CLI container"
+  fi
+
+
+  if [ "${DOCTOR_CHECK_WEBSERVER}" == "1" ]; then
+    host_app_port="$(docker port $(docker-compose ps -q ckan) 3000 | cut -d : -f 2)"
+    if ! curl -L -s -o /dev/null -w "%{http_code}" "${LAGOON_LOCALDEV_URL}:${host_app_port}" | grep -q 200; then
+      error "Web server is not accessible at ${LAGOON_LOCALDEV_URL}:${host_app_port}"
+      exit 1
+    fi
+    success "Web server is running and accessible at ${LAGOON_LOCALDEV_URL}:${host_app_port}"
+  fi
+
+  if [ "${DOCTOR_CHECK_BOOTSTRAP}" == "1" ]; then
+    host_app_port="$(docker port $(docker-compose ps -q ckan) 3000 | cut -d : -f 2)"
+    if ! curl -L -s -N "${LAGOON_LOCALDEV_URL}:${host_app_port}" | grep -q -i "meta name=\"generator\" content=\"ckan"; then
+      error "Website is running, but cannot be bootstrapped. Try pulling latest container images with 'ahoy pull'"
+      exit 1
+    fi
+    success "Successfully bootstrapped website at ${LAGOON_LOCALDEV_URL}:${host_app_port}"
+  fi
+
+  status "All required checks have passed"
+}
+
+#
+# Check that command exists.
+#
+command_exists() {
+  local cmd=$1
+  command -v "${cmd}" | grep -ohq "${cmd}"
+  local res=$?
+
+  # Try homebrew lookup, if brew is available.
+  if command -v "brew" | grep -ohq "brew" && [ "$res" == "1" ] ; then
+    brew --prefix "${cmd}" > /dev/null
+    res=$?
+  fi
+
+  echo ${res}
+}
+
+#
+# Status echo.
+#
+status() {
+  cecho blue "✚ $1";
+}
+
+#
+# Success echo.
+#
+success() {
+  cecho green "  ✓ $1";
+}
+
+#
+# Error echo.
+#
+error() {
+  cecho red "  ✘ $1";
+  exit 1
+}
+
+#
+# Colored echo.
+#
+cecho() {
+  local prefix="\033["
+  local input_color=$1
+  local message="$2"
+
+  local color=""
+  case "$input_color" in
+    black  | bk) color="${prefix}0;30m";;
+    red    |  r) color="${prefix}1;31m";;
+    green  |  g) color="${prefix}1;32m";;
+    yellow |  y) color="${prefix}1;33m";;
+    blue   |  b) color="${prefix}1;34m";;
+    purple |  p) color="${prefix}1;35m";;
+    cyan   |  c) color="${prefix}1;36m";;
+    gray   | gr) color="${prefix}0;37m";;
+    *) message="$1"
+  esac
+
+  # Format message with color codes, but only if a correct color was provided.
+  [ -n "$color" ] && message="${color}${message}${prefix}0m"
+
+  echo -e "$message"
+}
+
+main "$@"

--- a/.docker/scripts/init-ext.sh
+++ b/.docker/scripts/init-ext.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+##
+# Install current extension.
+#
+set -e
+
+. /app/ckan/default/bin/activate
+
+pip install -r "/app/requirements.txt"
+pip install -r "/app/dev-requirements.txt"
+python setup.py develop
+installed_name=$(grep '^\s*name=' setup.py |sed "s|[^']*'\([-a-zA-Z0-9]*\)'.*|\1|")
+
+# Validate that the extension was installed correctly.
+if ! pip list | grep "$installed_name" > /dev/null; then echo "Unable to find the extension in the list"; exit 1; fi
+
+deactivate

--- a/.docker/scripts/init.sh
+++ b/.docker/scripts/init.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+##
+# Initialise CKAN instance.
+#
+set -e
+
+CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
+CKAN_USER_PASSWORD="${CKAN_USER_PASSWORD:-Password123!}"
+CKAN_USER_EMAIL="${CKAN_USER_EMAIL:-admin@localhost}"
+
+. /app/ckan/default/bin/activate \
+  && cd /app/ckan/default/src/ckan \
+  && paster db clean -c /app/ckan/default/production.ini \
+  && paster db init -c /app/ckan/default/production.ini \
+  && paster --plugin=ckan user add "${CKAN_USER_NAME}" email="${CKAN_USER_EMAIL}" password="${CKAN_USER_PASSWORD}" -c /app/ckan/default/production.ini \
+  && paster --plugin=ckan sysadmin add "${CKAN_USER_NAME}" -c /app/ckan/default/production.ini
+
+# Create some base test data
+. /app/scripts/create-test-data.sh

--- a/.docker/scripts/init.sh
+++ b/.docker/scripts/init.sh
@@ -4,16 +4,18 @@
 #
 set -e
 
+CKAN_INI_FILE=/app/ckan/default/production.ini
 CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
 CKAN_USER_PASSWORD="${CKAN_USER_PASSWORD:-Password123!}"
 CKAN_USER_EMAIL="${CKAN_USER_EMAIL:-admin@localhost}"
 
 . /app/ckan/default/bin/activate \
   && cd /app/ckan/default/src/ckan \
-  && paster db clean -c /app/ckan/default/production.ini \
-  && paster db init -c /app/ckan/default/production.ini \
-  && paster --plugin=ckan user add "${CKAN_USER_NAME}" email="${CKAN_USER_EMAIL}" password="${CKAN_USER_PASSWORD}" -c /app/ckan/default/production.ini \
-  && paster --plugin=ckan sysadmin add "${CKAN_USER_NAME}" -c /app/ckan/default/production.ini
+  && paster db clean -c $CKAN_INI_FILE \
+  && paster db init -c $CKAN_INI_FILE \
+  && paster --plugin=ckanext-validation validation init-db -c $CKAN_INI_FILE \
+  && paster --plugin=ckan user add "${CKAN_USER_NAME}" email="${CKAN_USER_EMAIL}" password="${CKAN_USER_PASSWORD}" -c $CKAN_INI_FILE \
+  && paster --plugin=ckan sysadmin add "${CKAN_USER_NAME}" -c $CKAN_INI_FILE
 
 # Create some base test data
 . /app/scripts/create-test-data.sh

--- a/.docker/scripts/serve.sh
+++ b/.docker/scripts/serve.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+dockerize -wait tcp://postgres:5432 -timeout 1m
+dockerize -wait tcp://solr:8983 -timeout 1m
+
+sed -i "s@SITE_URL@${SITE_URL}@g" /app/ckan/default/production.ini
+
+. /app/ckan/default/bin/activate \
+    && paster serve /app/ckan/default/production.ini

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -95,7 +95,11 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats scheming validation
+ckan.plugins = validation scheming_datasets
+
+scheming.dataset_schemas = ckanext.validation.examples:ckan_default_schema.json
+scheming.presets = ckanext.scheming:presets.json
+				   ckanext.validation:presets.json
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -1,0 +1,206 @@
+#
+# CKAN - Pylons configuration
+#
+# These are some of the configuration options available for your CKAN
+# instance. Check the documentation in 'doc/configuration.rst' or at the
+# following URL for a description of what they do and the full list of
+# available options:
+#
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+
+[DEFAULT]
+debug = false
+smtp_server = localhost
+error_email_from = paste@localhost
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 3000
+
+[app:main]
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/%(ckan.site_id)s/
+
+# This is the secret token that the beaker library uses to hash the cookie sent
+# to the client. `paster make-config` generates a unique value for this each
+# time it generates a config file.
+beaker.session.secret = bSmgPpaxg2M+ZRes3u1TXwIcE
+
+# `paster make-config` generates a unique value for this each time it generates
+# a config file.
+app_instance_uuid = 6e3daf8e-1c6b-443b-911f-c7ab4c5f9605
+
+who.config_file = %(here)s/who.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who_log.ini
+
+## Database Settings
+sqlalchemy.url = postgresql://ckan:ckan@postgres/ckan?sslmode=disable
+
+ckan.datastore.write_url = postgresql://ckan:ckan@postgres-datastore/ckan?sslmode=disable
+ckan.datastore.read_url = postgresql://ckan_datastore:ckan@postgres-datastore/ckan?sslmode=disable
+
+# PostgreSQL' full-text search parameters
+ckan.datastore.default_fts_lang = english
+ckan.datastore.default_fts_index_method = gist
+
+## Site Settings.
+ckan.site_url = http://ckan:3000/
+
+## Authorization Settings
+
+ckan.auth.anon_create_dataset = false
+ckan.auth.create_unowned_dataset = false
+ckan.auth.create_dataset_if_not_in_organization = false
+ckan.auth.user_create_groups = false
+ckan.auth.user_create_organizations = false
+ckan.auth.user_delete_groups = true
+ckan.auth.user_delete_organizations = true
+ckan.auth.create_user_via_api = false
+ckan.auth.create_user_via_web = true
+ckan.auth.roles_that_cascade_to_sub_groups = admin
+ckan.auth.public_user_details = False
+
+
+## Search Settings
+
+ckan.site_id = default
+solr_url = http://solr:8983/solr/ckan
+
+
+## Redis Settings
+
+# URL to your Redis instance, including the database to be used.
+ckan.redis.url = redis://redis:6379
+
+
+## CORS Settings
+
+# If cors.origin_allow_all is true, all origins are allowed.
+# If false, the cors.origin_whitelist is used.
+# ckan.cors.origin_allow_all = true
+# cors.origin_whitelist is a space separated list of allowed domains.
+# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+
+## Plugins Settings
+
+# Note: Add ``datastore`` to enable the CKAN DataStore
+#       Add ``datapusher`` to enable DataPusher
+#       Add ``resource_proxy`` to enable resource proxying and get around the
+#       same origin policy
+# @todo:setup Cleanup the list to use only required plugins.
+ckan.plugins = stats scheming validation
+
+# Define which views should be created by default
+# (plugins must be loaded in ckan.plugins)
+ckan.views.default_views = image_view text_view recline_view
+
+# Customize which text formats the text_view plugin will show
+#ckan.preview.json_formats = json
+#ckan.preview.xml_formats = xml rdf rdf+xml owl+xml atom rss
+#ckan.preview.text_formats = text plain text/plain
+
+# Customize which image formats the image_view plugin will show
+#ckan.preview.image_formats = png jpeg jpg gif
+
+## Front-End Settings
+ckan.favicon = https://www.qld.gov.au/favicon.ico
+
+## Internationalisation Settings
+ckan.locale_default = en_AU
+ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
+ckan.locales_offered =
+ckan.locales_filtered_out = en_AU
+
+## Feeds Settings
+
+ckan.feeds.authority_name =
+ckan.feeds.date =
+ckan.feeds.author_name =
+ckan.feeds.author_link =
+
+## Storage Settings
+
+ckan.storage_path = /app/filestore
+#ckan.max_resource_size = 10
+#ckan.max_image_size = 2
+
+## Datapusher settings
+
+# Make sure you have set up the DataStore
+
+#ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+#ckan.datapusher.url = http://127.0.0.1:8800/
+#ckan.datapusher.assume_task_stale_after = 3600
+
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
+
+## Activity Streams Settings
+
+#ckan.activity_streams_enabled = true
+#ckan.activity_list_limit = 31
+#ckan.activity_streams_email_notifications = true
+#ckan.email_notifications_since = 2 days
+ckan.hide_activity_from_users = %(ckan.site_id)s
+
+
+## Email settings
+
+#email_to = errors@example.com
+#error_email_from = ckan-errors@example.com
+#smtp.server = localhost
+#smtp.starttls = False
+#smtp.user = username@example.com
+#smtp.password = your_password
+#smtp.mail_from =
+
+## Harvester settings
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = redis
+ckan.harvest.mq.port = 6379
+ckan.harvest.mq.redis_db = 0
+
+## Logging configuration
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+
+[logger_ckan]
+level = INFO
+handlers = console
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,19 @@
+[flake8]
+# @see https://flake8.pycqa.org/en/latest/user/configuration.html?highlight=.flake8
+
+exclude =
+    ckan
+    scripts
+
+# Extended output format.
+format = pylint
+
+# Show the source of errors.
+show_source = True
+
+max-complexity = 10
+
+# List ignore rules one per line.
+ignore =
+    E501
+    C901

--- a/.flake8
+++ b/.flake8
@@ -17,3 +17,5 @@ max-complexity = 10
 ignore =
     E501
     C901
+    W503
+    W504

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ignore files for distribution archives.
+/.ahoy.yml           export-ignore
+/.circleci           export-ignore
+/.docker             export-ignore
+/.env                export-ignore
+/.gitatributes       export-ignore
+/docker-compose.yml  export-ignore
+/test                export-ignore

--- a/ckanext/validation/commands.py
+++ b/ckanext/validation/commands.py
@@ -111,7 +111,6 @@ target yourself. Not to be used with -r or -d.''')
                                help='''Location of the CSV validation
 report file on the relevant commands.''')
 
-
     _page_size = 100
 
     def command(self):
@@ -309,7 +308,7 @@ report file on the relevant commands.''')
                                 outputs['resources_' + resource['validation_status']] += 1
 
                             if resource.get('validation_status') in (
-                                        'failure', 'error'):
+                                    'failure', 'error'):
                                 if full:
                                     row_counts = self._process_row_full(dataset, resource, writer)
                                     if not row_counts:
@@ -331,7 +330,6 @@ report file on the relevant commands.''')
                                     outputs['formats_success'][resource['format']] += 1
                                 else:
                                     outputs['formats_success'][resource['format']] = 1
-
 
                     if len(query['results']) < self._page_size:
                         break
@@ -380,6 +378,5 @@ Formats breakdown (validation failed or errored):
 {msg_errors}
 CSV Report stored in {output_csv}
 '''.format(**outputs)
-
 
         log.info(msg)

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -148,6 +148,7 @@ to create the database tables:
         return self._process_schema_fields(data_dict)
 
     resources_to_validate = {}
+    packages_to_skip = {}
 
     def after_create(self, context, data_dict):
 
@@ -185,6 +186,9 @@ to create the database tables:
     def before_update(self, context, current_resource, updated_resource):
 
         updated_resource = self._process_schema_fields(updated_resource)
+
+        # the call originates from a resource API, so don't validate the entire package
+        self.packages_to_skip[updated_resource['package_id']] = True
 
         if not get_update_mode_from_config() == u'async':
             return updated_resource
@@ -227,6 +231,11 @@ to create the database tables:
 
         if data_dict.get(u'resources'):
             # This is a dataset
+            package_id = data_dict.get('id')
+            if package_id in self.packages_to_skip:
+                del self.packages_to_skip[package_id]
+                return
+
             for resource in data_dict[u'resources']:
                 if resource[u'id'] in self.resources_to_validate:
                     # This is part of a resource_update call, it will be

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -173,11 +173,11 @@ to create the database tables:
             resource.get(u'url_type') == u'upload' or
             # URL defined
             resource.get(u'url')
-            ) and (
+        ) and (
             # Make sure format is supported
             resource.get(u'format', u'').lower() in
                 settings.SUPPORTED_FORMATS
-                )):
+        )):
             needs_validation = True
 
         if needs_validation:
@@ -194,7 +194,7 @@ to create the database tables:
             return updated_resource
 
         needs_validation = False
-        if ((
+        if (
             # New file uploaded
             updated_resource.get(u'upload') or
             # External URL changed
@@ -205,11 +205,10 @@ to create the database tables:
             # Format changed
             (updated_resource.get(u'format', u'').lower() !=
              current_resource.get(u'format', u'').lower())
-            ) and (
+        ) and (
             # Make sure format is supported
             updated_resource.get(u'format', u'').lower() in
-                settings.SUPPORTED_FORMATS
-                )):
+                settings.SUPPORTED_FORMATS):
             needs_validation = True
 
         if needs_validation:

--- a/ckanext/validation/tests/test_form.py
+++ b/ckanext/validation/tests/test_form.py
@@ -123,7 +123,7 @@ class TestResourceSchemaForm(FunctionalTestBase):
         form['url'] = 'https://example.com/data.csv'
 
         webtest_submit(
-                form, 'save', upload_files=[upload], extra_environ=env)
+            form, 'save', upload_files=[upload], extra_environ=env)
 
         dataset = call_action('package_show', id=dataset['id'])
 
@@ -298,7 +298,7 @@ class TestResourceSchemaForm(FunctionalTestBase):
         form['url'] = 'https://example.com/data.csv'
 
         webtest_submit(
-                form, 'save', upload_files=[upload], extra_environ=env)
+            form, 'save', upload_files=[upload], extra_environ=env)
 
         dataset = call_action('package_show', id=dataset['id'])
 

--- a/ckanext/validation/tests/test_helpers.py
+++ b/ckanext/validation/tests/test_helpers.py
@@ -115,8 +115,8 @@ class TestExtractReportFromErrors(object):
         }
 
         errors = {
-          'some_field': ['Some error'],
-          'validation': [report],
+            'some_field': ['Some error'],
+            'validation': [report],
         }
 
         extracted_report, errors = validation_extract_report_from_errors(
@@ -132,8 +132,8 @@ class TestExtractReportFromErrors(object):
     def test_report_not_extracted(self):
 
         errors = {
-          'some_field': ['Some error'],
-          'some_other_field': ['Some other error']
+            'some_field': ['Some error'],
+            'some_other_field': ['Some other error']
         }
 
         report, errors = validation_extract_report_from_errors(errors)

--- a/ckanext/validation/tests/test_jobs.py
+++ b/ckanext/validation/tests/test_jobs.py
@@ -15,8 +15,8 @@ from ckanext.validation.model import create_tables, tables_exist, Validation
 from ckanext.validation.jobs import (
     run_validation_job, uploader, Session)
 from ckanext.validation.tests.helpers import (
-        VALID_REPORT, INVALID_REPORT, ERROR_REPORT, VALID_REPORT_LOCAL_FILE,
-        mock_uploads, MockFieldStorage
+    VALID_REPORT, INVALID_REPORT, ERROR_REPORT, VALID_REPORT_LOCAL_FILE,
+    mock_uploads, MockFieldStorage
 )
 
 
@@ -41,8 +41,7 @@ class TestValidationJob(object):
     @mock.patch('ckanext.validation.jobs.validate')
     @mock.patch.object(Session, 'commit')
     @mock.patch.object(ckantoolkit, 'get_action')
-    def test_job_run_no_schema(
-         self, mock_get_action, mock_commit, mock_validate):
+    def test_job_run_no_schema(self, mock_get_action, mock_commit, mock_validate):
 
         org = factories.Organization()
         dataset = factories.Dataset(private=True, owner_org=org['id'])
@@ -64,8 +63,7 @@ class TestValidationJob(object):
     @mock.patch('ckanext.validation.jobs.validate')
     @mock.patch.object(Session, 'commit')
     @mock.patch.object(ckantoolkit, 'get_action')
-    def test_job_run_schema(
-         self, mock_get_action, mock_commit, mock_validate):
+    def test_job_run_schema(self, mock_get_action, mock_commit, mock_validate):
 
         org = factories.Organization()
         dataset = factories.Dataset(private=True, owner_org=org['id'])
@@ -174,7 +172,7 @@ class TestValidationJob(object):
             self, mock_uploader, mock_validate):
 
         resource = factories.Resource(
-                url='__upload', url_type='upload', format='csv')
+            url='__upload', url_type='upload', format='csv')
 
         run_validation_job(resource)
 

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -16,8 +16,8 @@ import ckantoolkit as t
 
 from ckanext.validation.model import create_tables, tables_exist, Validation
 from ckanext.validation.tests.helpers import (
-        VALID_CSV, INVALID_CSV, VALID_REPORT,
-        mock_uploads, MockFieldStorage
+    VALID_CSV, INVALID_CSV, VALID_REPORT,
+    mock_uploads, MockFieldStorage
 )
 
 
@@ -472,12 +472,12 @@ class TestResourceValidationOnCreate(FunctionalTestBase):
 
             with assert_raises(t.ValidationError) as e:
 
-                    call_action(
-                        'resource_create',
-                        package_id=dataset['id'],
-                        format='CSV',
-                        upload=mock_upload
-                    )
+                call_action(
+                    'resource_create',
+                    package_id=dataset['id'],
+                    format='CSV',
+                    upload=mock_upload
+                )
 
         assert 'validation' in e.exception.error_dict
         assert 'missing-value' in str(e.exception)

--- a/ckanext/validation/tests/test_utils.py
+++ b/ckanext/validation/tests/test_utils.py
@@ -160,5 +160,4 @@ class TestFiles(object):
 
             delete_local_uploaded_file(resource_id)
 
-
         patcher.tearDown()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,7 @@
+behave==1.2.6
+behaving==1.5.6
+flake8==3.7.9
+nose==1.3.7
+splinter>=0.13.0
+-e git+https://github.com/ckan/ckanapi@ckanapi-4.3#egg=ckanapi
 pyfakefs==2.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,100 @@
+version: '2.3'
+
+x-project:
+  &project ckanext-validation
+
+x-volumes:
+  &default-volumes
+  volumes:
+    - /app/ckan ### Local overrides to mount host filesystem. Automatically removed in CI and PROD.
+    - ./ckanext:/app/ckanext:${VOLUME_FLAGS:-delegated} ### Local overrides to mount host filesystem. Automatically removed in CI and PROD.
+    - ./test:/app/test:${VOLUME_FLAGS:-delegated} ### Local overrides to mount host filesystem. Automatically removed in CI and PROD.
+    ##- /app/filestore # Override for environment without host mounts. Automatically uncommented in CI.
+
+x-environment:
+  &default-environment
+  AMAZEEIO: AMAZEEIO
+  no_proxy: "ckan,postgres,postgres-datastore,redis,solr,chrome,mailhog.docker.amazee.io"
+
+x-user:
+  &default-user
+  # The default user under which the containers should run.
+  # Change this if you are on linux and run with another user than id `1000`.
+  user: '1000'
+
+services:
+
+  ckan:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.ckan
+      args:
+        SITE_URL: http://ckanext-validation.docker.amazee.io
+    depends_on:
+      - postgres
+      - solr
+    networks:
+      - amazeeio-network
+      - default
+    ports:
+      - "3000"
+    image: *project
+    <<: *default-volumes
+    environment:
+      <<: *default-environment
+      AMAZEEIO_HTTP_PORT: 3000
+      LAGOON_LOCALDEV_URL: http://ckanext-validation.docker.amazee.io
+      AMAZEEIO_URL: ckanext-validation.docker.amazee.io
+
+  postgres:
+    image: amazeeio/postgres-ckan
+    ports:
+      - "5432"
+    networks:
+      - amazeeio-network
+      - default
+    <<: *default-user
+    environment:
+      <<: *default-environment
+
+  redis:
+    image: amazeeio/redis
+    <<: *default-user
+    environment:
+      <<: *default-environment
+    networks:
+      - amazeeio-network
+      - default
+
+  solr:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile.solr
+    user: '8983'
+    ports:
+      - "8983"
+    environment:
+      <<: *default-environment
+    networks:
+      - amazeeio-network
+      - default
+
+  chrome:
+    image: selenium/standalone-chrome:3.141.59-oxygen
+    shm_size: '1gb'
+    depends_on:
+      - ckan
+    <<: *default-volumes
+    <<: *default-user
+    environment:
+      <<: *default-environment
+    networks:
+      - amazeeio-network
+      - default
+
+volumes:
+  solr-data: {}
+
+networks:
+  amazeeio-network:
+    external: true

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ setup(
     namespace_packages=['ckanext'],
 
     install_requires=[
-      # CKAN extensions should not list dependencies here, but in a separate
-      # ``requirements.txt`` file.
-      #
-      # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
+        # CKAN extensions should not list dependencies here, but in a separate
+        # ``requirements.txt`` file.
+        #
+        # http://docs.ckan.org/en/latest/extensions/best-practices.html#add-third-party-libraries-to-requirements-txt
     ],
 
     # If there are data files included in your packages that need to be

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -1,0 +1,89 @@
+import os
+from behaving import environment as benv
+
+from behaving.web.steps.browser import named_browser
+
+# Path to the root of the project.
+ROOT_PATH = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
+
+# Base URL for relative paths resolution.
+BASE_URL = 'http://ckan:3000/'
+
+# URL of remote Chrome instance.
+REMOTE_CHROME_URL = 'http://chrome:4444/wd/hub'
+
+# @see .docker/scripts/init.sh for credentials.
+PERSONAS = {
+    'Admin': dict(
+        name=u'admin',
+        email=u'admin@localhost',
+        password=u'Password123!'
+    ),
+    'Organisation Admin': dict(
+        name=u'organisation_admin',
+        email=u'organisation_admin@localhost',
+        password=u'Password123!'
+    ),
+    'Group Admin': dict(
+        name=u'group_admin',
+        email=u'group_admin@localhost',
+        password=u'Password123!'
+    ),
+    'Publisher': dict(
+        name=u'publisher',
+        email=u'publisher@localhost',
+        password=u'Password123!'
+    ),
+    'Walker': dict(
+        name=u'walker',
+        email=u'walker@localhost',
+        password=u'Password123!'
+    ),
+    'Foodie': dict(
+        name=u'foodie',
+        email=u'foodie@localhost',
+        password=u'Password123!'
+    )
+}
+
+
+def before_all(context):
+    # The path where screenshots will be saved.
+    context.screenshots_dir = os.path.join(ROOT_PATH, 'test/screenshots')
+    # The path where file attachments can be found.
+    context.attachment_dir = os.path.join(ROOT_PATH, 'test/fixtures')
+
+    # Set base url for all relative links.
+    context.base_url = BASE_URL
+
+    # Always use remote web driver.
+    context.remote_webdriver = 1
+    context.default_browser = 'chrome'
+    context.browser_args = {'command_executor': REMOTE_CHROME_URL}
+
+    # Set the rest of the settings to default Behaving's settings.
+    benv.before_all(context)
+
+
+def after_all(context):
+    benv.after_all(context)
+
+
+def before_feature(context, feature):
+    benv.before_feature(context, feature)
+
+
+def after_feature(context, feature):
+    benv.after_feature(context, feature)
+
+
+def before_scenario(context, scenario):
+    benv.before_scenario(context, scenario)
+    # Always use remote browser.
+    named_browser(context, 'remote')
+    # Set personas.
+    context.personas = PERSONAS
+
+
+def after_scenario(context, scenario):
+    benv.after_scenario(context, scenario)

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -1,0 +1,7 @@
+@smoke
+Feature: Homepage
+
+    @homepage
+    Scenario: Smoke test to ensure Homepage is accessible
+        When I go to homepage
+        Then I take a screenshot

--- a/test/features/login.feature
+++ b/test/features/login.feature
@@ -1,0 +1,18 @@
+@smoke @login
+Feature: Login
+
+    Scenario: Smoke test to ensure Login process works
+        Given "Admin" as the persona
+        When I go to homepage
+        And I click the link with text that contains "Log in"
+        And I fill in "login" with "$name"
+        And I fill in "password" with "$password"
+        # Login is a button without "name" or "id".
+        And I press the element with xpath "//button[contains(string(), 'Login')]"
+        And I take a screenshot
+        Then I should see an element with xpath "//a[contains(string(), 'Log out')]"
+
+    Scenario: Smoke test to ensure Login step works
+        Given "Admin" as the persona
+        When I log in
+        Then I take a screenshot

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -1,0 +1,13 @@
+@resources
+Feature: Resource UI
+
+    Scenario Outline: Link resource should create a link to its URL
+        Given "Admin" as the persona
+        When I create a resource with name "<name>" and URL "<url>"
+        And I press the element with xpath "//a[contains(@title, '<name>') and contains(string(), '<name>')]"
+        Then I take a screenshot
+        And I should see "<url>"
+
+        Examples:
+        | name | url |
+        | link | http://www.qld.gov.au |

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -1,6 +1,7 @@
 @resources
 Feature: Resource UI
 
+    @format_autocomplete
     Scenario Outline: Link resource should create a link to its URL
         Given "Admin" as the persona
         When I create a resource with name "<name>" and URL "<url>"

--- a/test/features/resources.feature
+++ b/test/features/resources.feature
@@ -10,4 +10,4 @@ Feature: Resource UI
 
         Examples:
         | name | url |
-        | link | http://www.qld.gov.au |
+        | link | http://example.com |

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -22,6 +22,7 @@ def log_in(context):
         Then I should see an element with xpath "//a[contains(string(), 'Log out')]"
     """)
 
+
 @step('I create a resource with name "{name}" and URL "{url}"')
 def add_resource(context, name, url):
     context.execute_steps(u"""
@@ -65,7 +66,7 @@ def go_to_user_profile(context, user_id):
 
 
 @step('I go to the dashboard')
-def go_to_user_profile(context):
+def go_to_dashboard(context):
     when_i_visit_url(context, '/dashboard')
 
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -1,0 +1,84 @@
+from behave import step
+from behaving.web.steps import *  # noqa: F401, F403
+from behaving.personas.steps import *  # noqa: F401, F403
+from behaving.web.steps.url import when_i_visit_url
+
+
+@step('I go to homepage')
+def go_to_home(context):
+    when_i_visit_url(context, '/')
+
+
+@step('I log in')
+def log_in(context):
+
+    assert context.persona
+    context.execute_steps(u"""
+        When I go to homepage
+        And I click the link with text that contains "Log in"
+        And I fill in "login" with "$name"
+        And I fill in "password" with "$password"
+        And I press the element with xpath "//button[contains(string(), 'Login')]"
+        Then I should see an element with xpath "//a[contains(string(), 'Log out')]"
+    """)
+
+@step('I create a resource with name "{name}" and URL "{url}"')
+def add_resource(context, name, url):
+    context.execute_steps(u"""
+        When I log in
+        And I visit "/dataset/new_resource/warandpeace"
+        And I press the element with xpath "//form[@id='resource-edit']//a[string() = 'Link']"
+        And I fill in "name" with "{}"
+        And I fill in "url" with "{}"
+        And I press the element with xpath "//button[contains(string(), 'Add')]"
+    """.format(name, url))
+
+
+@step('I go to dataset page')
+def go_to_dataset_page(context):
+    when_i_visit_url(context, '/dataset')
+
+
+@step('I go to organisation page')
+def go_to_organisation_page(context):
+    when_i_visit_url(context, '/organization')
+
+
+@step('I go to register page')
+def go_to_register_page(context):
+    when_i_visit_url(context, '/user/register')
+
+
+@step('I search the autocomplete API for user "{username}"')
+def go_to_user_autocomplete(context, username):
+    when_i_visit_url(context, '/api/2/util/user/autocomplete?q={}'.format(username))
+
+
+@step('I go to the user list API')
+def go_to_user_list(context):
+    when_i_visit_url(context, '/api/3/action/user_list')
+
+
+@step('I go to the "{user_id}" profile page')
+def go_to_user_profile(context, user_id):
+    when_i_visit_url(context, '/user/{}'.format(user_id))
+
+
+@step('I go to the dashboard')
+def go_to_user_profile(context):
+    when_i_visit_url(context, '/dashboard')
+
+
+@step('I go to the "{user_id}" user API')
+def go_to_user_show(context, user_id):
+    when_i_visit_url(context, '/api/3/action/user_show?id={}'.format(user_id))
+
+
+@step('I view the "{group_id}" group API "{including}" users')
+def go_to_group_including_users(context, group_id, including):
+    when_i_visit_url(context, r'/api/3/action/group_show?id={}&include_users={}'.format(group_id, including in ['with', 'including']))
+
+
+@step('I view the "{organisation_id}" organisation API "{including}" users')
+def go_to_organisation_including_users(context, organisation_id, including):
+    when_i_visit_url(context, r'/api/3/action/organization_show?id={}&include_users={}'.format(organisation_id, including in ['with', 'including']))


### PR DESCRIPTION
Github #49

# Overview

When calling `before_update` for a resource, flag the package to be skipped (once) by `after_update` since we don't want to update other resources.

This is necessary because resource update calls will first trigger `after_update` with the package object, which (without this change) will re-validate every resource whether it needs it or not. We can't rely on the `resources_to_validate` dictionary to exclude individual resources, because a) the updated resource might not have been placed in that dictionary if it was a trivial update, and b) any _other_ resources in the package definitely won't be in the dict.

---

Please preserve this line to notify @amercader (lead of this repository)
