### PR TITLE
Support foreign key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,30 @@ With the extension enabled and configured, schemas can be attached to the
 `schema` field on resources via the UI form or the API. If present in a
 resource, they will be used when performing validation on the resource file.
 
+#### Foreign Keys
+
+As per the Frictionless Framework, ckanext-validation can also be used to
+validate foreign keys. This is done by adding a `foreignKeys` property to the
+schema, with the following format:
+
+```json
+{
+    "foreignKeys": [
+        {
+            "fields": "location",
+            "reference": {
+                "resource": "locations",
+                "fields": "code"
+            }
+        }
+    ]
+}
+```
+
+This will validate that the values in the `location` column are present in the
+`code` column of the `locations` resource. The `resource` property can be
+either the full url of a resource, a valid Frictionless Schema in JSON or the
+`resource_type` that matches another resource within the CKAN dataset.
 
 ### Validation Options
 

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -64,7 +64,7 @@ def run_validation_job(resource):
             # implementation)
             pass_auth_header = t.asbool(
                 t.config.get('ckanext.validation.pass_auth_header', True))
-            if dataset['private'] and pass_auth_header:
+            if pass_auth_header:
                 s = requests.Session()
                 s.headers.update({
                     'Authorization': t.config.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.3
-frictionless==5.0.0b9
+frictionless[ckan]==5.0.0b9
 markupsafe==2.0.1
 tableschema
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
## Description

closes #84

Basically, I have rewritten `_validate_table` to use the frictionless [Package](https://framework.frictionlessdata.io/docs/framework/package.html) object, instead of the [Resource](https://framework.frictionlessdata.io/docs/framework/resource.html) object.

This allows us to then pass in multiple resources and do the following:
 - if "foreignKeys" is in the schema we collect together `schema["foreignKeys"][i]["reference"]["resource"]
 - we go through and check if the referenced resource is a url (path), json object (data) or (the fall back) is a resource name that can be found within this ckan dataset; if none are true then we return a `ValidationError`
 - these can be added to our `Package` object for frictionless framework to utilise during validation

## Testing

TODO - I am working on these today.

## Documentation

I have updated the documentation to explain how to use foreign keys. It's fairly brief at the moment but probably in line with other similar parts.