### PR TITLE
Site-wide validation overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,12 @@ You can also provide [validation options](#validation-options) that will be
 used by default when running the validation:
 
 	ckanext.validation.default_validation_options={
-	    "skip_errors": ["blank-row", "duplicate-label"],
-    	}
+	    "skip_checks": ["blank-rows", "duplicate-label"]}
+
+Or overrides to ensure some validation options are used site-wide, regardless of the schema provided in the resource:
+
+	ckanext.validation.override_validation_options={
+            "encoding": "utf8"}
 
 Make sure to use indentation if the value spans multiple lines otherwise it
 won't be parsed.

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -51,6 +51,10 @@ def run_validation_job(resource):
     if resource_options:
         options.update(resource_options)
 
+    options.update(json.loads(t.config.get(
+        'ckanext.validation.override_validation_options',
+        '{}')))
+
     dataset = t.get_action('package_show')(
         {'ignore_auth': True}, {'id': resource['package_id']})
 


### PR DESCRIPTION
We use this to implement a "UTF-8-only" policy, but the same could be used for standardizing other options across a site with a configuration option.