### PR TITLE
Fix Upload Field Condition

### DIFF
--- a/ckanext/validation/plugin/__init__.py
+++ b/ckanext/validation/plugin/__init__.py
@@ -225,7 +225,8 @@ to create the database tables:
         needs_validation = False
         if ((
             # New file uploaded
-            updated_resource.get(u'upload') or
+            (updated_resource.get(u'upload') or
+             getattr(updated_resource.get(u'upload'), 'file', False)) or
             # External URL changed
             updated_resource.get(u'url') != current_resource.get(u'url') or
             # Schema changed


### PR DESCRIPTION
fix(dev): FieldStorage support;

- Added condition to check for `file` attribute from FieldStorage object for `ckanapi` support.

CKANAPI uses cgi.FieldStorage (https://github.com/ckan/ckanapi/blob/master/ckanapi/localckan.py#L67) as to not require a lot of dependencies. Related issue on cgi.FieldStorage: https://bugs.python.org/issue19097

To support all py versions and cgi dependency versions, just checking for the `file` attribute might be good enough?