### PR TITLE
CKAN 2.10/2.11 compatibility: startup crash, resource_create 500, and silently-skipped async validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       matrix:
         include: #ckan-image see https://github.com/ckan/ckan-docker-base, ckan-version controls other image tags
-#          - ckan-version: "2.11"
-#            ckan-image: "2.11-py3.10"
-#            ckan-solr: "2.11-solr9"
-#            experimental: false
-#          - ckan-version: "2.10"
-#            ckan-image: "2.10-py3.10"
-#            ckan-solr: "2.10-solr9"
-#            experimental: false
+          - ckan-version: "2.11"
+            ckan-image: "2.11-py3.10"
+            ckan-solr: "2.11-solr9"
+            experimental: false
+          - ckan-version: "2.10"
+            ckan-image: "2.10-py3.10"
+            ckan-solr: "2.10-solr9"
+            experimental: false
           - ckan-version: "2.9"
             ckan-image: "2.9-py3.9"
             ckan-solr: "2.9-solr8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
       CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
       CKAN_SOLR_URL: http://solr:8983/solr/ckan
       CKAN_REDIS_URL: redis://redis:6379/1
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
     - uses: actions/checkout@v4
@@ -106,6 +107,9 @@ jobs:
 
     - name: "Upload coverage report to codecov flag: ${{ matrix.ckan-version }}"
       uses: codecov/codecov-action@v5
+      # secrets are unavailable on pull_request runs from forks; skip the
+      # upload rather than failing the job
+      if: ${{ env.CODECOV_TOKEN != '' }}
       continue-on-error: ${{ matrix.experimental }}
       with:
         file: ./coverage.xml

--- a/ckanext/validation/model.py
+++ b/ckanext/validation/model.py
@@ -57,5 +57,11 @@ def tables_exist():
         # Engine not initialised yet (plugin update_config runs before
         # model.init_model on first load); `validation init-db` creates it.
         return True
-    return 'validation' in metadata.tables \
-        and inspect(engine).has_table('validation')
+    inspector = inspect(engine)
+    if hasattr(inspector, 'has_table'):
+        # SQLAlchemy >= 1.4 (CKAN >= 2.10)
+        has_table = inspector.has_table
+    else:
+        # SQLAlchemy 1.3 (CKAN 2.9); Table.exists() is gone in 1.4
+        has_table = engine.has_table
+    return 'validation' in metadata.tables and has_table('validation')

--- a/ckanext/validation/model.py
+++ b/ckanext/validation/model.py
@@ -51,5 +51,11 @@ def create_tables():
 
 
 def tables_exist():
+    from sqlalchemy import inspect
+    engine = model.meta.engine
+    if engine is None:
+        # Engine not initialised yet (plugin update_config runs before
+        # model.init_model on first load); `validation init-db` creates it.
+        return True
     return 'validation' in metadata.tables \
-        and metadata.tables['validation'].exists()
+        and inspect(engine).has_table('validation')

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -262,6 +262,14 @@ Please run the following to create the database tables:
             if utils.should_remove_unsupported_resource_validation_reports(data_dict):
                 p.toolkit.enqueue_job(fn=utils.remove_unsupported_resource_validation_reports, args=[resource_id])
 
+    # CKAN >= 2.10: IPackageController fires the *_dataset_* hook names; the
+    # dataset-flavoured branches live in the after_resource_* methods above.
+    def after_dataset_create(self, context, data_dict):
+        return self.after_resource_create(context, data_dict)
+
+    def after_dataset_update(self, context, data_dict):
+        return self.after_resource_update(context, data_dict)
+
     # IPackageController
 
     # CKAN < 2.10

--- a/ckanext/validation/tests/fixtures.py
+++ b/ckanext/validation/tests/fixtures.py
@@ -13,4 +13,7 @@ def validation_setup():
 @pytest.fixture
 def mock_uploads(ckan_config, monkeypatch, tmp_path):
     monkeypatch.setitem(ckan_config, "ckan.storage_path", str(tmp_path))
-    monkeypatch.setattr(uploader, "_storage_path", str(tmp_path))
+    # CKAN >= 2.10 has no module-level _storage_path cache; the config
+    # item above is what its uploader reads
+    monkeypatch.setattr(uploader, "_storage_path", str(tmp_path),
+                        raising=False)

--- a/ckanext/validation/tests/helpers.py
+++ b/ckanext/validation/tests/helpers.py
@@ -134,7 +134,7 @@ def mock_uploads_fake_fs(func):
     @mock.patch.object(builtins, 'open',
                        side_effect=_mock_open_if_open_fails)
     @mock.patch.object(ckan.lib.uploader, '_storage_path',
-                       new='/doesnt_exist')
+                       new='/doesnt_exist', create=True)
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)

--- a/ckanext/validation/tests/test_form.py
+++ b/ckanext/validation/tests/test_form.py
@@ -31,7 +31,7 @@ def _get_resource_new_page_as_sysadmin(app, id):
     user = Sysadmin()
     env = {"REMOTE_USER": user["name"].encode("ascii")}
     response = app.get(
-        url="/dataset/new_resource/{}".format(id),
+        url=_new_resource_url(id),
         extra_environ=env,
     )
     return env, response
@@ -41,7 +41,7 @@ def _get_resource_update_page_as_sysadmin(app, id, resource_id):
     user = Sysadmin()
     env = {"REMOTE_USER": user["name"].encode("ascii")}
     response = app.get(
-        url="/dataset/{}/resource_edit/{}".format(id, resource_id),
+        url=_edit_resource_url(id, resource_id),
         extra_environ=env,
     )
     return env, response

--- a/ckanext/validation/tests/test_jobs.py
+++ b/ckanext/validation/tests/test_jobs.py
@@ -212,9 +212,9 @@ class TestValidationJob(object):
 
         resource = factories.Resource(format="csv", upload=mock_upload)
 
-        invalid_stream = io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))
+        invalid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(invalid_csv.encode("utf8")))
 
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=invalid_stream):
             run_validation_job(resource)
 
         validation = (
@@ -258,9 +258,9 @@ a;b;c
             format="csv", upload=mock_upload, validation_options=validation_options
         )
 
-        invalid_stream = io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))
+        invalid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(invalid_csv.encode("utf8")))
 
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=invalid_stream):
 
             run_validation_job(resource)
 

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -566,9 +566,9 @@ class TestResourceValidationOnCreate(object):
 
         dataset = factories.Dataset()
 
-        valid_stream = io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))
+        valid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(VALID_CSV.encode("utf8")))
 
-        with mock.patch("io.open", return_value=valid_stream):
+        with mock.patch("io.open", side_effect=valid_stream):
 
             resource = call_action(
                 "resource_create",
@@ -611,9 +611,9 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(invalid_file, "invalid.csv")
 
-        invalid_stream = io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))
+        invalid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(INVALID_CSV.encode("utf8")))
 
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=invalid_stream):
 
             with pytest.raises(t.ValidationError) as e:
 
@@ -637,9 +637,9 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(invalid_file, "invalid.csv")
 
-        invalid_stream = io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))
+        invalid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(INVALID_CSV.encode("utf8")))
 
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=invalid_stream):
 
             with pytest.raises(t.ValidationError):
 
@@ -663,9 +663,9 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(valid_file, "valid.csv")
 
-        valid_stream = io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))
+        valid_stream = lambda *a, **kw: io.BufferedReader(io.BytesIO(VALID_CSV.encode("utf8")))
 
-        with mock.patch("io.open", return_value=valid_stream):
+        with mock.patch("io.open", side_effect=valid_stream):
 
             resource = call_action(
                 "resource_update",

--- a/ckanext/validation/tests/test_model.py
+++ b/ckanext/validation/tests/test_model.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import pytest
+
+from ckan import model as ckan_model
+
+from ckanext.validation import model as validation_model
+
+
+class TestTablesExist(object):
+
+    def test_no_engine_yet(self):
+        # On first load plugin.update_config runs before model.init_model,
+        # so there is no engine to inspect; tables_exist() must not crash
+        # (`validation init-db` creates the tables later).
+        with mock.patch.object(ckan_model.meta, "engine", None):
+            assert validation_model.tables_exist() is True
+
+    @pytest.mark.usefixtures("clean_db", "validation_setup")
+    def test_tables_exist_after_init(self):
+        # SQLAlchemy 1.4 (CKAN >= 2.10) removed Table.exists(); make sure
+        # the inspector-based check still sees the created tables.
+        assert validation_model.tables_exist() is True

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -337,3 +337,43 @@ class TestPackageControllerHooksUpdate(object):
         call_action("package_update", {}, **dataset)
 
         mock_enqueue.assert_not_called()
+
+
+@pytest.mark.usefixtures("clean_db", "validation_setup", "with_plugins")
+class TestDatasetControllerHooks(object):
+    # CKAN >= 2.10 fires after_dataset_create/after_dataset_update on
+    # IPackageController; without those methods async validation silently
+    # never runs for package-level calls (harvesters, API package_update).
+
+    @mock.patch("ckanext.validation.utils.run_async_validation")
+    def test_package_create_triggers_validation(self, mock_run):
+
+        factories.Dataset(
+            resources=[{"format": "CSV", "url": "https://example.com/d.csv"}]
+        )
+
+        assert mock_run.call_count == 1
+
+    @mock.patch("ckanext.validation.utils.run_async_validation")
+    def test_package_update_triggers_validation(self, mock_run):
+
+        dataset = factories.Dataset(
+            resources=[{"format": "CSV", "url": "https://example.com/d.csv"}]
+        )
+        mock_run.reset_mock()
+
+        dataset["resources"][0]["url"] = "https://example.com/d2.csv"
+        call_action("package_update", {}, **dataset)
+
+        assert mock_run.call_count == 1
+
+    @mock.patch("ckanext.validation.utils.run_async_validation")
+    def test_package_create_unsupported_format_does_not_validate(
+        self, mock_run
+    ):
+
+        factories.Dataset(
+            resources=[{"format": "PDF", "url": "https://example.com/d.pdf"}]
+        )
+
+        mock_run.assert_not_called()

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from unittest import mock
 
@@ -191,7 +193,7 @@ class TestPackageControllerHooksCreate(object):
     @mock.patch("ckanext.validation.logic.action.enqueue_job")
     def test_validation_run_with_upload(self, mock_enqueue):
 
-        resource = {"id": "test-resource-id", "format": "CSV", "url_type": "upload"}
+        resource = {"id": str(uuid.uuid4()), "format": "CSV", "url_type": "upload"}
         factories.Dataset(resources=[resource])
 
         assert mock_enqueue.call_count == 1
@@ -203,7 +205,7 @@ class TestPackageControllerHooksCreate(object):
     def test_validation_run_with_url(self, mock_enqueue):
 
         resource = {
-            "id": "test-resource-id",
+            "id": str(uuid.uuid4()),
             "format": "CSV",
             "url": "http://some.data",
         }
@@ -218,12 +220,12 @@ class TestPackageControllerHooksCreate(object):
     def test_validation_run_only_supported_formats(self, mock_enqueue):
 
         resource1 = {
-            "id": "test-resource-id-1",
+            "id": str(uuid.uuid4()),
             "format": "CSV",
             "url": "http://some.data",
         }
         resource2 = {
-            "id": "test-resource-id-2",
+            "id": str(uuid.uuid4()),
             "format": "PDF",
             "url": "http://some.doc",
         }
@@ -244,11 +246,11 @@ class TestPackageControllerHooksUpdate(object):
     def test_validation_runs_with_url(self, mock_enqueue):
 
         resource = {
-            "id": "test-resource-id",
+            "id": str(uuid.uuid4()),
             "format": "CSV",
             "url": "http://some.data",
         }
-        dataset = factories.Dataset(resources=[resource], id="myid")
+        dataset = factories.Dataset(resources=[resource])
 
         mock_enqueue.assert_not_called()
 
@@ -265,7 +267,7 @@ class TestPackageControllerHooksUpdate(object):
     @mock.patch("ckanext.validation.logic.action.enqueue_job")
     def test_validation_runs_with_upload(self, mock_enqueue):
 
-        resource = {"id": "test-resource-id", "format": "CSV", "url_type": "upload"}
+        resource = {"id": str(uuid.uuid4()), "format": "CSV", "url_type": "upload"}
         dataset = factories.Dataset(resources=[resource])
 
         mock_enqueue.assert_not_called()
@@ -283,7 +285,7 @@ class TestPackageControllerHooksUpdate(object):
     @mock.patch("ckanext.validation.logic.action.enqueue_job")
     def test_validation_does_not_run_on_other_formats(self, mock_enqueue):
 
-        resource = {"id": "test-resource-id", "format": "PDF", "url": "http://some.doc"}
+        resource = {"id": str(uuid.uuid4()), "format": "PDF", "url": "http://some.doc"}
         dataset = factories.Dataset(resources=[resource])
 
         mock_enqueue.assert_not_called()
@@ -299,12 +301,12 @@ class TestPackageControllerHooksUpdate(object):
     def test_validation_run_only_supported_formats(self, mock_enqueue):
 
         resource1 = {
-            "id": "test-resource-id-1",
+            "id": str(uuid.uuid4()),
             "format": "CSV",
             "url": "http://some.data",
         }
         resource2 = {
-            "id": "test-resource-id-2",
+            "id": str(uuid.uuid4()),
             "format": "PDF",
             "url": "http://some.doc",
         }
@@ -328,7 +330,7 @@ class TestPackageControllerHooksUpdate(object):
     def test_validation_does_not_run_when_config_false(self, mock_enqueue):
 
         resource = {
-            "id": "test-resource-id",
+            "id": str(uuid.uuid4()),
             "format": "CSV",
             "url": "http://some.data",
         }

--- a/ckanext/validation/tests/test_utils.py
+++ b/ckanext/validation/tests/test_utils.py
@@ -159,3 +159,36 @@ class TestFiles(object):
             delete_local_uploaded_file(resource_id)
 
         patcher.tearDown()
+
+
+class TestProcessSchemaFields(object):
+    # CKAN 2.11 removed uploader.ALLOWED_UPLOAD_TYPES and
+    # uploader._get_underlying_file, which this function relied on to read
+    # an uploaded schema file; uploads arrive as werkzeug FileStorage on
+    # every supported CKAN version.
+
+    def test_schema_upload_filestorage_is_read(self):
+        from io import BytesIO
+
+        from werkzeug.datastructures import FileStorage
+
+        from ckanext.validation.utils import process_schema_fields
+
+        schema = b'{"fields": [{"name": "code"}]}'
+        data_dict = process_schema_fields(
+            {
+                "schema_upload": FileStorage(
+                    BytesIO(schema), filename="schema.json"
+                )
+            }
+        )
+
+        assert data_dict["schema"] == schema.decode()
+        assert "schema_upload" not in data_dict
+
+    def test_schema_json_still_wins_without_upload(self):
+        from ckanext.validation.utils import process_schema_fields
+
+        data_dict = process_schema_fields({"schema_json": '{"fields": []}'})
+
+        assert data_dict["schema"] == '{"fields": []}'

--- a/ckanext/validation/utils.py
+++ b/ckanext/validation/utils.py
@@ -3,6 +3,7 @@ import logging
 
 from six import string_types, ensure_str
 
+from werkzeug.datastructures import FileStorage as FlaskFileStorage
 import ckan.plugins as plugins
 import ckan.lib.uploader as uploader
 from ckan import model
@@ -34,9 +35,9 @@ def process_schema_fields(data_dict):
     schema_url = data_dict.pop(u'schema_url', None)
     schema_json = data_dict.pop(u'schema_json', None)
 
-    if isinstance(schema_upload, uploader.ALLOWED_UPLOAD_TYPES):
+    if isinstance(schema_upload, FlaskFileStorage):
         data_dict[u'schema'] = ensure_str(
-            uploader._get_underlying_file(schema_upload).read())
+            schema_upload.stream.read())
         if isinstance(data_dict["schema"], (bytes, bytearray)):
             data_dict["schema"] = data_dict["schema"].decode()
     elif schema_url:

--- a/test.ini
+++ b/test.ini
@@ -10,6 +10,8 @@ port = 5000
 
 [app:main]
 use = config:../../src/ckan/test-core.ini
+# CKAN >= 2.10 enables CSRF in the test app; form tests post directly
+WTF_CSRF_ENABLED = false
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
Three fixes that together make the extension functional on CKAN 2.11 (SQLAlchemy 1.4). Each is a separate commit; happy to split into separate PRs if preferred.

## 1. `tables_exist()` crashes at plugin load (fixes #118)

`Table.exists()` was removed in SQLAlchemy 1.4; #119 fixed `create_tables()` the same way but this call site remained, so CKAN 2.11 crash-loops the moment the plugin is enabled:

```
File "ckanext/validation/model.py", line 55, in tables_exist
    and metadata.tables['validation'].exists()
sqlalchemy.exc.UnboundExecutionError: Table object 'validation' is not bound to an Engine or Connection.
```

Fixed with `sqlalchemy.inspect(engine).has_table()`. One subtlety: `update_config` runs before CKAN calls `model.init_model` on first load, so `model.meta.engine` can be `None` there — since the check in `update_config` is purely advisory (it logs a hint to run `validation init-db`), that case is treated as fine instead of raising `NoInspectionAvailable`.

## 2. Every `resource_create` 500s on CKAN 2.11

CKAN 2.11 removed `ckan.lib.uploader.ALLOWED_UPLOAD_TYPES` and `_get_underlying_file` (uploads are always werkzeug `FileStorage` now):

```
File "ckanext/validation/utils.py", line 37, in process_schema_fields
    if isinstance(schema_upload, uploader.ALLOWED_UPLOAD_TYPES):
AttributeError: module 'ckan.lib.uploader' has no attribute 'ALLOWED_UPLOAD_TYPES'
```

Fixed by testing against `FileStorage` and reading the stream directly. (Related: #96 extends this same condition for ckanapi's `cgi.FieldStorage` — that remains possible on top of this change.)

## 3. Async validation silently never triggers on CKAN >= 2.10

On CKAN >= 2.10, `IPackageController` fires `after_dataset_create` / `after_dataset_update` — but the plugin only defines the `IResourceController` names (`after_resource_create/update`), whose dataset-flavoured branches contain all the package-level validation dispatch. With `inherit=True` the dataset hooks fall through to the interface's no-op defaults, so on 2.10/2.11 the plugin loads and *appears* to work while never enqueuing a single validation job. Aliasing the dataset-named hooks to the existing implementations restores the dispatch. (Supersedes the plugin-hook portion of #98, rebased onto the current `plugin.py` layout.)

## Verification

All three verified on a live CKAN 2.11.5 deployment (Python 3.10, SQLAlchemy 1.4.52, frictionless via requirements.txt): clean plugin load, `validation init-db`, then `resource_create` with a malformed CSV → async job runs → `resource_validation_show` returns `status: failure` with the expected frictionless errors (blank-label, extra-cell, missing-cell), a clean CSV returns `status: success`, and the report page renders. We ship these as vendored patches in production today and would love to drop them.